### PR TITLE
Auto response model

### DIFF
--- a/modules/swagger-codegen/src/main/resources/hellofreshphp/HelloFreshClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/hellofreshphp/HelloFreshClient.mustache
@@ -22,6 +22,11 @@ class HelloFreshClient extends Client implements HelloFreshClientInterface
     const DEFAULT_USER_AGENT = 'HelloFreshClient';
 
     /**
+     * Define the model to use to unserialize a response.
+     */
+    const RESPONSE_MODEL = '#hf_response_model;
+
+    /**
     * @param  ResponseInterface $response
     * @return HelloFreshResponse
     */
@@ -140,4 +145,41 @@ class HelloFreshClient extends Client implements HelloFreshClientInterface
         return $this->forwardHttpMethod(__FUNCTION__, [ $request ]);
     }
 
+    /**
+     * @inheritdoc
+     */
+    protected function forwardHttpMethod($method, $arguments)
+    {
+        $model = null;
+
+        if ($method !== 'send') {
+            list($url, $options) = $arguments;
+
+            if (isset($arguments[self::RESPONSE_MODEL])) {
+                $model = $arguments[self::RESPONSE_MODEL];
+                unset($arguments[self::RESPONSE_MODEL]);
+            }
+        }
+
+        $response = parent::forwardHttpMethod($method, $arguments);
+
+        if ($model) {
+            $response->setModel($this->unserialize($model, $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Unserialize a response into a model
+     *
+     * @param string $modelClass The class of the model to instantiate.
+     * @param HelloFreshResponseInterface $response The response to unserialize
+     *
+     * @return mixed
+     */
+    protected function unserialize($modelClass, HelloFreshResponseInterface $response)
+    {
+        return Deserializer::deserialize($modelClass, $response);
+    }
 }

--- a/modules/swagger-codegen/src/main/resources/hellofreshphp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/hellofreshphp/api.mustache
@@ -38,11 +38,11 @@ class {{classname}} extends AbstractHelloFreshPurpose
             ];
         }
 
-        $response = $this->client->{{lcHttpMethod}}('{{path}}', $options);
         {{#returnType}}
-        $response->setModel(Deserializer::deserialize('{{returnType}}', $response));
+        $options[$this->client::RESPONSE_MODEL] = '{{returnType}}';
         {{/returnType}}
-        return $response;
+
+        return $this->client->{{lcHttpMethod}}('{{path}}', $options);
     }
 
 {{/operation}}


### PR DESCRIPTION
This PR moves the logic of the response model instantiation from each purpose methods to a single  point in the client. The main goal is obviously to have a single point of failure, but also to hide the unserialization business.

Instead of handling the unserialization itself,

``` php
$response = $this->client->get('/addresses/{id}', $options);
$response->setModel(Deserializer::deserialize('HelloFresh\HelloFreshClient\Entity\Address\Address', $response));

return $response;
```

The purpose now only defines which model to use:

``` php
return $this->client->get('/addresses/{id}', $options + [
    $this->client::RESPONSE_MODEL => 'HelloFresh\HelloFreshClient\Entity\Address\Address'
]);
```

Now it would be a good idea to replace the static _deserializer_ and inject it during the client construct.
